### PR TITLE
Handle cover/invoice pairs and improve UI

### DIFF
--- a/Example Folder for PDF Forms/Sample Cover Sheet.pdf
+++ b/Example Folder for PDF Forms/Sample Cover Sheet.pdf
@@ -1,0 +1,45 @@
+%PDF-1.3
+%
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 72 72 ]
+/Parent 1 0 R
+>>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000114 00000 n 
+0000000163 00000 n 
+trailer
+<<
+/Size 5
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+251
+%%EOF

--- a/Example Folder for PDF Forms/Sample Invoice.pdf
+++ b/Example Folder for PDF Forms/Sample Invoice.pdf
@@ -1,0 +1,45 @@
+%PDF-1.3
+%
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 72 72 ]
+/Parent 1 0 R
+>>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000114 00000 n 
+0000000163 00000 n 
+trailer
+<<
+/Size 5
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+251
+%%EOF


### PR DESCRIPTION
## Summary
- show a clearer subtitle about merging cover sheet and invoice PDFs
- check for selected "Cover Sheet"/"Invoice" pairs before processing
- group PDFs using `pair_cover_invoices` and merge each pair in order
- update CLI to use the same pairing logic
- add example `Sample Cover Sheet.pdf` and `Sample Invoice.pdf` files

## Testing
- `python -m py_compile invoice_flatten_merge.py`
- `python invoice_flatten_merge.py --help`

------
https://chatgpt.com/codex/tasks/task_e_688d05d31094833388b03763508a9ad6