### PR TITLE
Fix codesign environment vars

### DIFF
--- a/.github/workflows/Build-Mac-PDF.yml
+++ b/.github/workflows/Build-Mac-PDF.yml
@@ -1,23 +1,34 @@
+---
 name: macOS build
 
 on:
   push:
-    branches: [main]
+    tags: ["v*.*.*"]
   workflow_dispatch:
 
 jobs:
   build-macos:
     runs-on: macos-14
+    env:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.12" }
+        with:
+          python-version: "3.12"
 
       - run: pip install -r requirements.txt pyinstaller
 
       - name: Build .app
-        run: pyinstaller -y --windowed --name InvoiceMerge invoice_flatten_merge.py
+        run: |
+          pyinstaller -y --windowed \
+            invoice_flatten_merge.py --name InvoiceMerge
 
       - name: Install Ghostscript
         run: brew install ghostscript
@@ -26,9 +37,39 @@ jobs:
         run: |
           GS_PREFIX=$(brew --prefix ghostscript)
           mkdir -p dist/InvoiceMerge.app/Contents/Resources/ghostscript
-          cp "$GS_PREFIX/bin/gs" dist/InvoiceMerge.app/Contents/Resources/ghostscript/
+          cp "$GS_PREFIX/bin/gs" \
+            dist/InvoiceMerge.app/Contents/Resources/ghostscript/
           cp -R "$GS_PREFIX/lib" "$GS_PREFIX/share/ghostscript" \
             dist/InvoiceMerge.app/Contents/Resources/ghostscript/
+
+      - name: Import signing certificate
+        if: ${{ secrets.MACOS_CERTIFICATE }}
+        run: |
+          echo "$MACOS_CERTIFICATE" | base64 --decode > signing.p12
+          security create-keychain -p "" build.keychain
+          security import signing.p12 -k build.keychain -P \
+            "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security list-keychains -s build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+
+      - name: Codesign .app
+        if: ${{ secrets.MACOS_CERTIFICATE }}
+        run: |
+          codesign --deep --force --options runtime \
+            --sign "$MACOS_CODESIGN_IDENTITY" dist/InvoiceMerge.app
+
+      - name: Notarize .app
+        if: ${{ secrets.APPLE_ID }} && ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          xcrun notarytool submit dist/InvoiceMerge.app \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" --wait
+
+      - name: Staple notarization ticket
+        if: ${{ secrets.APPLE_ID }} && ${{ secrets.APPLE_APP_PASSWORD }}
+        run: xcrun stapler staple dist/InvoiceMerge.app
 
       - name: Create DMG
         run: |

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
 # flatten-pdf
 
 Utility for merging and flattening invoice PDFs. The repository contains a
-GitHub Actions workflow for building a signed macOS application bundle and DMG.
+GitHub Actions workflow for building a signed and notarized macOS application
+bundle and DMG.
 
 ## Building the macOS Application
 
 The workflow is defined in `.github/workflows/Build-Mac-PDF.yml`. It runs when
 you push a Git tag that matches `v*.*.*`. The job installs Python dependencies,
-builds the `.app` using PyInstaller, vendors Ghostscript via Homebrew and
-produces an `InvoiceMerge.dmg`.
+builds the `.app` using PyInstaller, vendors Ghostscript via Homebrew, signs and
+notarizes the bundle (when the required secrets are available) and produces an
+`InvoiceMerge.dmg`.
+
+### Required Secrets
+
+The workflow expects the following secrets to be configured on your repository
+for codesigning and notarization:
+
+- `MACOS_CERTIFICATE` – base64-encoded signing certificate (.p12)
+- `MACOS_CERTIFICATE_PASSWORD` – password for the certificate
+- `MACOS_CODESIGN_IDENTITY` – signing identity to use with `codesign`
+- `APPLE_ID` – your Apple ID used for notarization
+- `APPLE_TEAM_ID` – Developer Team ID
+- `APPLE_APP_PASSWORD` – app-specific password for notarization
 
 ### Triggering the workflow
 


### PR DESCRIPTION
## Summary
- inject secrets into the macOS build job as environment variables
- document all required secrets for codesigning and notarization
- fix YAML indentation issues and trigger on version tags

## Testing
- `python3 -m py_compile invoice_flatten_merge.py`
- `yamllint .github/workflows/Build-Mac-PDF.yml`


------
https://chatgpt.com/codex/tasks/task_e_688d1c88af848333b487e356798f5669